### PR TITLE
Fix circular references and some typos

### DIFF
--- a/binexport/__init__.py
+++ b/binexport/__init__.py
@@ -2,5 +2,5 @@ from .program import ProgramBinExport
 from .function import FunctionBinExport
 from .basic_block import BasicBlockBinExport
 from .instruction import InstructionBinExport
-from.operand import OperandBinExport
+from .operand import OperandBinExport
 from .expression import ExpressionBinExport

--- a/binexport/basic_block.py
+++ b/binexport/basic_block.py
@@ -14,7 +14,7 @@ class BasicBlockBinExport(OrderedDict):
     methods to access instructions.
     """
 
-    def __init__(self, program: "ProgramBinExport", function: "FunctionBinExport", pb_bb: "BinExport2.BasicBlock"):
+    def __init__(self, program: weakref.ref["ProgramBinExport"], function: weakref.ref["FunctionBinExport"], pb_bb: "BinExport2.BasicBlock"):
         """
         :param program: Weak reference to the program
         :param function: Weak reference to the function
@@ -29,16 +29,15 @@ class BasicBlockBinExport(OrderedDict):
         self.bytes = b""  #: bytes of the basic block
 
         # Ranges are in fact the true basic blocks but BinExport
-        # don't have the same basic block semantic and merge multiple basic blocks into one.
+        # doesn't have the same basic block semantic and merge multiple basic blocks into one.
         # For example: BB_1 -- unconditional_jmp --> BB_2
-        # might be merged into a single basic block so lose the edge
+        # might be merged into a single basic block so the edge gets lost.
         for rng in pb_bb.instruction_index:
             for idx in instruction_index_range(rng):
                 pb_inst = self.program.proto.instruction[idx]
                 inst_addr = get_instruction_address(self.program.proto, idx)
 
                 # The first instruction determines the basic block address
-                # Save the first instruction to guess the instruction set
                 if self.addr is None:
                     self.addr = inst_addr
 

--- a/binexport/instruction.py
+++ b/binexport/instruction.py
@@ -1,4 +1,5 @@
 import weakref
+from functools import cached_property
 
 from binexport.operand import OperandBinExport
 from binexport.types import Addr
@@ -10,7 +11,7 @@ class InstructionBinExport:
     Instruction class. It represents an instruction with its operands.
     """
 
-    def __init__(self, program: "ProgramBinExport", function: "FunctionBinExport", addr: Addr, i_idx: int):
+    def __init__(self, program: weakref.ref["ProgramBinExport"], function: weakref.ref["FunctionBinExport"], addr: Addr, i_idx: int):
         """
         :param program: Weak reference to the program
         :param function: Weak reference to the function
@@ -54,10 +55,11 @@ class InstructionBinExport:
         """
         return self.program.proto.mnemonic[self.pb_instr.mnemonic_index].name
 
-    @property
+    @cached_property
     def operands(self) -> List[OperandBinExport]:
         """
         Returns a list of the operands instanciated dynamically on-demand.
+        The list is cached by default, to erase the cache delete the attribute.
         """
         return [
             OperandBinExport(self._program, self._function, weakref.ref(self), op_idx)

--- a/binexport/operand.py
+++ b/binexport/operand.py
@@ -111,6 +111,7 @@ class OperandBinExport:
         """
         Iterates over all the operand expression in a pre-order manner
         (binary operator first).
+        The list is cached by default, to erase the cache delete the attribute
         """
 
         expr_dict = {}  # {expression protobuf idx : ExpressionBinExport}


### PR DESCRIPTION
Using cached properties from basic blocks up to expressions to avoid allocating twice the same objects.
In order to avoid circular references that usually lead to memory leaks since the python garbage collector doesn't deal with them very well, we are now using weak references.