### PR TITLE
update binexporter to enable batch diffing

### DIFF
--- a/bin/binexporter
+++ b/bin/binexporter
@@ -3,11 +3,14 @@
 
 import logging
 import os.path
-import pathlib
+from pathlib import Path
+from typing import Generator
 
 import magic
 import click
 
+from multiprocessing import Pool, Queue, Manager
+import queue
 from binexport import ProgramBinExport
 
 BINARY_FORMAT = {
@@ -22,6 +25,43 @@ EXTENSIONS_WHITELIST = {"application/octet-stream": [".dex"]}
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"], max_content_width=300)
 
+class Bcolors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKCYAN = '\033[96m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+
+def recursive_file_iter(p: Path) -> Generator[Path, None, None]:
+    if p.is_file():
+        mime_type = magic.from_file(p, mime=True)
+        if mime_type not in BINARY_FORMAT and p.suffix not in EXTENSIONS_WHITELIST.get(
+            mime_type, []
+        ):
+            pass
+        else:
+            yield p
+    elif p.is_dir():
+        for f in p.iterdir():
+            yield from recursive_file_iter(f)
+
+
+def export_job(ingress, egress) -> bool:
+    while True:
+        try:
+            file = ingress.get(timeout=0.5)
+            res = ProgramBinExport.from_binary_file(file.as_posix(), open_export=False)
+            egress.put((file, res))
+        except queue.Empty:
+            pass
+        except KeyboardInterrupt:
+            break
+
 
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.option(
@@ -31,41 +71,62 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"], max_content_width=30
     default=None,
     help="IDA Pro installation directory",
 )
+@click.option("-t", "--threads", type=int, default=1, help="Thread number to use")
 @click.option("-v", "--verbose", count=True, help="To activate or not the verbosity")
-@click.argument("input_file", type=click.Path(exists=True), metavar="<binary file>")
-def main(ida_path: str, input_file: str, verbose: bool) -> None:
+@click.argument("input_file", type=click.Path(exists=True), metavar="<binary file|directory>")
+def main(ida_path: str, input_file: str, threads: int, verbose: bool) -> None:
     """
     binexporter is a very simple utility to generate a .BinExport file
-    for a given binary. It all open the binary file and export the file
+    for a given binary or a directory. It all open the binary file and export the file
     seamlessly.
 
     :param ida_path: Path to the IDA Pro installation directory
     :param input_file: Path of the binary to export
+    :param threads: number of threads to use
     :param verbose: To activate or not the verbosity
     :return: None
     """
 
     logging.basicConfig(
-        format="[%(levelname)s] %(message)s", level=logging.DEBUG if verbose else logging.INFO
+        format="%(message)s", level=logging.DEBUG if verbose else logging.INFO
     )
 
     if ida_path:
-        os.environ["IDA_PATH"] = pathlib.Path(ida_path).absolute().as_posix()
+        os.environ["IDA_PATH"] = Path(ida_path).absolute().as_posix()
 
-    mime_type = magic.from_file(input_file, mime=True)
-    input_file = pathlib.Path(input_file)
-    if mime_type not in BINARY_FORMAT and input_file.suffix not in EXTENSIONS_WHITELIST.get(
-        mime_type, []
-    ):
-        logging.error("the file is not an executable file")
-        exit(1)
+    root_path = Path(input_file)
 
-    if ProgramBinExport.from_binary_file(input_file.as_posix()):
-        logging.info("binexport written to: %s" % input_file.with_suffix(".BinExport"))
-        exit(0)
-    else:
-        exit(1)
+    manager = Manager()
+    ingress = manager.Queue()
+    egress = manager.Queue()
+    pool = Pool(threads)
 
+    # Launch all workers
+    for _ in range(threads):
+        pool.apply_async(export_job, (ingress, egress))
+
+    # Pre-fill ingress queue
+    total = 0
+    for file in recursive_file_iter(root_path):
+        ingress.put(file)
+        total += 1
+
+    logging.info(f"Start exporting {total} binaries")
+
+    i = 0
+    while True:
+        item = egress.get()
+        i += 1
+        path, res = item
+        if res:
+            pp_res = Bcolors.OKGREEN + "OK" + Bcolors.ENDC
+        else:
+            pp_res = Bcolors.FAIL + "KO" + Bcolors.ENDC
+        logging.info(f"[{i}/{total}] {str(path) + '.BinExport'} [{pp_res}]")
+        if i == total:
+            break
+
+    pool.terminate()
 
 if __name__ == "__main__":
     main()

--- a/binexport/program.py
+++ b/binexport/program.py
@@ -107,7 +107,7 @@ class ProgramBinExport(dict):
         output_file: str | pathlib.Path = "",
         open_export: bool = True,
         override: bool = False,
-    ) -> "ProgramBinExport | None":
+    ) -> "ProgramBinExport | bool":
         """
         Generate the .BinExport file for the given program and return an instance
         of ProgramBinExport.
@@ -118,7 +118,8 @@ class ProgramBinExport(dict):
         :param output_file: BinExport output file
         :param open_export: whether or not to open the binexport after export
         :param override: Override the .BinExport if already existing. (default false)
-        :return: an instance of ProgramBinExport
+        :return: an instance of ProgramBinExport if open_export is true, else boolean
+                 on whether it succeeded
         """
 
         from idascript import IDA
@@ -135,7 +136,7 @@ class ProgramBinExport(dict):
             if open_export:
                 return ProgramBinExport(binexport_file)
             else:
-                return None
+                return True
 
         ida = IDA(
             exec_file,
@@ -153,13 +154,13 @@ class ProgramBinExport(dict):
             logging.warning(
                 f"{exec_file.name} failed to export [ret:{retcode}, binexport:{binexport_file.exists()}]"
             )
-            return None
+            return False
 
         if binexport_file.exists():
-            return ProgramBinExport(binexport_file) if open_export else None
+            return ProgramBinExport(binexport_file) if open_export else True
         else:
             logging.error(f"{exec_file} can't find binexport generated")
-            return None
+            return False
 
     @property
     def proto(self) -> BinExport2:


### PR DESCRIPTION
By default binexporter only enables exporting one file.

I though it allowed to batch exporter a given directory recursively. Unfortunately it does not.

So I added to possibility to multi process easily the export of binaries.
