### PR TITLE
Add regression tests and testing CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/data/** filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,35 @@
+name: Testing
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  testing:
+    name: Run tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: |
+            3.11
+            3.12
+            3.10
+
+      - name: Install dependencies
+        run: pip install .[dev]
+
+      - name: Running pytest
+        run: tox run -- -s
+
+      - name: Generate coverage
+        run: tox run -e py310-coverage -- -s --cov-report=term
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: ./htmlcov

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ build/
 dist/
 *.egg-info/
 /venv/
+.tox/
+.coverage
+htmlcov/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ Documentation = "https://quarkslab.github.io/diffing-portal/exporter/binexport.h
 [project.scripts]
 binexporter = 'binexport.__main__:main'
 
+[project.optional-dependencies]
+dev = ["tox"]
+
 [tool.black]
 line-length = 100
 target-version = ['py310']

--- a/tests/data/MachO-OSX-ppc-and-i386-bash.BinExport
+++ b/tests/data/MachO-OSX-ppc-and-i386-bash.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df5b9cc6f8c82ba241094e4be6171cb54a6fe031f58c458e5d066843c385ed45
+size 3282130

--- a/tests/data/MachO-OSX-ppc-openssl-1.0.1h.BinExport
+++ b/tests/data/MachO-OSX-ppc-openssl-1.0.1h.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c49739d075290a8bb4d59915afe9cf04a7a55dce8ab05c8bf047babcd5733db7
+size 2591355

--- a/tests/data/MachO-OSX-x64-ls.BinExport
+++ b/tests/data/MachO-OSX-x64-ls.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f2ce6243be93216cb7bac71b3f5bd58969feeee293a72fda94915d114ab0886
+size 124714

--- a/tests/data/MachO-OSX-x86-ls.BinExport
+++ b/tests/data/MachO-OSX-x86-ls.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8b60ee9d440e71de8f09cb66a3a4cd898e67b308cad3cd753d0ba796f02f542
+size 134033

--- a/tests/data/MachO-iOS-arm1176JZFS-bash.BinExport
+++ b/tests/data/MachO-iOS-arm1176JZFS-bash.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2ca343df07370aa8b1f5b8679ff9f85b508fbf0a1954e910e907194b841c53b
+size 7855967

--- a/tests/data/MachO-iOS-armv7-armv7s-arm64-Helloworld.BinExport
+++ b/tests/data/MachO-iOS-armv7-armv7s-arm64-Helloworld.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abd8e1298f8563a75467920b7a64877c838de38cc34708c1bd17b19ec3ce2633
+size 108656

--- a/tests/data/MachO-iOS-armv7s-Helloworld.BinExport
+++ b/tests/data/MachO-iOS-armv7s-Helloworld.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2155f08336fde101c74983c8ad8ed651f3f373ad282b12148d8f726a6e685421
+size 125994

--- a/tests/data/elf-FreeBSD-x86_64-echo.BinExport
+++ b/tests/data/elf-FreeBSD-x86_64-echo.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ce6401efe23cae4d87a436aed44938b8eea80932b68174be64471fd949f720f
+size 18860

--- a/tests/data/elf-HPUX-ia64-bash.BinExport
+++ b/tests/data/elf-HPUX-ia64-bash.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a93367698a55a070479d59a53c01abbe1e5a355f0d006ecfa92ad59e02730f41
+size 9916496

--- a/tests/data/elf-Haiku-GCC2-ls.BinExport
+++ b/tests/data/elf-Haiku-GCC2-ls.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:633dd7f7eb7b7e28468a241aa4de2f4539e41297bfff3cd24230e175d47b1341
+size 781729

--- a/tests/data/elf-Haiku-GCC7-WebPositive.BinExport
+++ b/tests/data/elf-Haiku-GCC7-WebPositive.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:328c47712b831cf621d9fd669aaadc9944b73ace4196290140aa334c3031c5b3
+size 2287557

--- a/tests/data/elf-Linux-ARM64-bash.BinExport
+++ b/tests/data/elf-Linux-ARM64-bash.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed8cd3ea5537d2d8c58f3254fb06b1053cca83152958e95c48ed0d1a29a05941
+size 4978154

--- a/tests/data/elf-Linux-ARMv7-ls.BinExport
+++ b/tests/data/elf-Linux-ARMv7-ls.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7d2799ef2a8b6af514f99546c7128339fd9be3c36a1678e01c9d28fbe2619b8
+size 468834

--- a/tests/data/elf-Linux-Alpha-bash.BinExport
+++ b/tests/data/elf-Linux-Alpha-bash.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a545621ffcba86a3a3bc7d498dfc69ef8a523ddace663770c6094283dc512c44
+size 4599405

--- a/tests/data/elf-Linux-Mips4-bash.BinExport
+++ b/tests/data/elf-Linux-Mips4-bash.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f76a76cf4ca6596cdf0e65c68637bedff1d975641c86ac4b886b4f3e3de59b7
+size 5480024

--- a/tests/data/elf-Linux-PowerPC-bash.BinExport
+++ b/tests/data/elf-Linux-PowerPC-bash.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e63409ffe9aa23ce03ee3e5e480a809c56250271c5d8ae4d1d2deb525369fde
+size 5599906

--- a/tests/data/elf-Linux-SparcV8-bash.BinExport
+++ b/tests/data/elf-Linux-SparcV8-bash.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8350f5f074c41be58e0e5ab0ca496277f2a4a15a006c106c7e86e1c6ba8c3683
+size 4788353

--- a/tests/data/elf-Linux-SuperH4-bash.BinExport
+++ b/tests/data/elf-Linux-SuperH4-bash.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1d1e44f1118b012bfe0fd345aace39f0ba2ac19634210a16894203a36aabf70
+size 4702239

--- a/tests/data/elf-Linux-hppa-bash.BinExport
+++ b/tests/data/elf-Linux-hppa-bash.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd695a3b3f7a96488c4810130f96e82c87d60c9a263de7aef35ea9bfddf63edd
+size 4204731

--- a/tests/data/elf-Linux-ia64-bash.BinExport
+++ b/tests/data/elf-Linux-ia64-bash.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:849506d514ec06f42a08a643c0d3997d376c335e472cb24deb03ef072a238ce2
+size 5466741

--- a/tests/data/elf-Linux-lib-x64.so.BinExport
+++ b/tests/data/elf-Linux-lib-x64.so.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af4097b31dffd55fe7527cc209b403a2d1621b8e652c66ad1a0b88afc05750e8
+size 4825458

--- a/tests/data/elf-Linux-lib-x86.so.BinExport
+++ b/tests/data/elf-Linux-lib-x86.so.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c40342d8258b4f4334d5aa1677296aec36b6816ad8f461885ae0562be109f4df
+size 5184423

--- a/tests/data/elf-Linux-s390-bash.BinExport
+++ b/tests/data/elf-Linux-s390-bash.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f24eec5f4cc3c2f6b2087df155b83fcd5a4f7cf28bb917a042dac96e3bc4c809
+size 3764863

--- a/tests/data/elf-Linux-x64-bash.BinExport
+++ b/tests/data/elf-Linux-x64-bash.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4cbac994bd17877001b1816680cf02d369f916eb7dae5ffe838c4a5cf4de8ce7
+size 4150225

--- a/tests/data/elf-Linux-x86-bash.BinExport
+++ b/tests/data/elf-Linux-x86-bash.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e67e7158258315ed1d432810fbbd435ce65fd75205da8cc249a127f5ce90ce2
+size 4171659

--- a/tests/data/elf-NetBSD-x86_64-echo.BinExport
+++ b/tests/data/elf-NetBSD-x86_64-echo.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7733931455b441f58e6ebf248ee829b999351c813a1f4a9f7520ec76d4230b54
+size 11076

--- a/tests/data/elf-OpenBSD-x86_64-sh.BinExport
+++ b/tests/data/elf-OpenBSD-x86_64-sh.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a29c656709885d70655c526e38815bd4c5e4ae104e4fb33a0e23c9bf34273fde
+size 2956000

--- a/tests/data/elf-solaris-sparc-ls.BinExport
+++ b/tests/data/elf-solaris-sparc-ls.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f65ae2f71eb413aeaf92e4d53e61e92e2766a7abf2885e980052be1e2e85b413
+size 874096

--- a/tests/data/elf-solaris-x86-ls.BinExport
+++ b/tests/data/elf-solaris-x86-ls.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34c7907d923045d72007a96bccab79051e14faf6586b19946b8de6f3b3e32b66
+size 787734

--- a/tests/data/libSystem.B.dylib.BinExport
+++ b/tests/data/libSystem.B.dylib.BinExport
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e6862ff0c1a5e5e7d4002434473ae898a6dca001d5eba66a7d0b5dff1428d66
+size 18793

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,18 @@
+import glob
+from itertools import islice
+
+from binexport import ProgramBinExport
+
+
+def test_from_protobuf():
+    """Regression tests for loading from protobuf"""
+
+    for filename in glob.glob("tests/data/*"):
+        print(f"Analyzing {filename}...")
+        p = ProgramBinExport(filename)
+        for func in p.values():
+            for bb in islice(func.blocks.values(), 0, 2):
+                for instr in islice(bb.instructions.values(), 0, 2):
+                    for op in instr.operands:
+                        for expr in op.expressions:
+                            pass

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 min_version = 4.6.3
 env_list =
+    py312
     py311
     py310
 
@@ -11,7 +12,7 @@ wheel_build_env = .pkg
 deps = pytest>=7
 commands = pytest {tty:--color=yes} {posargs}
 
-[testenv:coverage]
+[testenv:{py310,py311,py312}-coverage]
 description = get the code coverage of the tests
 package = wheel
 wheel_build_env = .pkg

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,22 @@
+[tox]
+min_version = 4.6.3
+env_list =
+    py311
+    py310
+
+[testenv]
+description = run the tests
+package = wheel
+wheel_build_env = .pkg
+deps = pytest>=7
+commands = pytest {tty:--color=yes} {posargs}
+
+[testenv:coverage]
+description = get the code coverage of the tests
+package = wheel
+wheel_build_env = .pkg
+deps =
+    pytest>=7
+    pytest-cov>=4.1
+commands =
+    pytest {tty:--color=yes} --cov=binexport --cov-report=html {posargs}


### PR DESCRIPTION
Add initial version of regression tests (to be extended in the future) and add a CI for running the tests at each commit and each PR.
The CI will also generate the coverage