### PR TITLE
Do not install python-magic on windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [{ name = "Quarkslab", email = "diffing@quarkslab.com" }]
 license = {text = "AGPL-3.0"}
 requires-python = ">=3.9"
 dependencies = [
-    "python-magic",
+    "python-magic; os_name!='nt'",
     "python-magic-bin; os_name=='nt'",
     "click",
     "protobuf",


### PR DESCRIPTION
Needed until https://github.com/ahupp/python-magic/pull/294 is merged into main