### PR TITLE
Implement the Binary Ninja exporter backend

### DIFF
--- a/src/binexport/types.py
+++ b/src/binexport/types.py
@@ -61,6 +61,7 @@ class DisassemblerBackend(enum.Enum):
     """
 
     # fmt: off
-    IDA = enum.auto()        # doc: IDA backend
-    GHIDRA = enum.auto()     # doc: Ghidra backend 
+    IDA = enum.auto()           # doc: IDA backend
+    GHIDRA = enum.auto()        # doc: Ghidra backend
+    BINARY_NINJA = enum.auto()  # doc: BinaryNinja backend 
     # fmt: on


### PR DESCRIPTION
Implements the Binary Ninja exporter backend.

I made sure appropriate backends are used depending on provided command-line arguments, but didn't tested Ghidra and IDA backends on my machine (if you have some time to test them).

Note: On my machine, passing the backend around as a global wasn't working. The `BACKEND` variable wasn't updated even if declared with the `global` keyword in `main`. For this reason, I declared it in `main` as a local variable and passed it to `export_job` as a parameter.

